### PR TITLE
🔧 chore(sidebar): show all items in sidebar for testing

### DIFF
--- a/Web/Helpers/SidebarHelper.cs
+++ b/Web/Helpers/SidebarHelper.cs
@@ -2,7 +2,7 @@
 {
     public class SidebarHelper
     {
-        public static List<SidebarItem> GetSidebarItems(string activeRole)
+        public static List<SidebarItem> GetSidebarItems(string? activeRole)
         {
             if (string.IsNullOrEmpty(activeRole))
                 return new List<SidebarItem>();
@@ -21,9 +21,11 @@
                 new SidebarItem { Title = "Usuarios", Controller = "Users", Action = "Index", Icon = "fa-solid fa-users", Roles = new[] { "administrador" } }
             };
 
-            return allItems
-                .Where(item => item.Roles.Any(r => r.ToLower() == activeRole))
-                .ToList();
+            return allItems;
+
+            // return allItems
+            //     .Where(item => item.Roles.Any(r => r.ToLower() == activeRole))
+            //     .ToList();
         }
     }
 }


### PR DESCRIPTION
- Updated SidebarHelper to return all items without filtering by role.
- Allows viewing the full navigation regardless of the user's role.
- Null warnings for ActiveRole handled with a nullable parameter.