### PR TITLE
🐛 fix(user-crud): remove password from GROUP BY in User_CRUD procedure

### DIFF
--- a/Api/Data/Scripts/stored_procedures.sql
+++ b/Api/Data/Scripts/stored_procedures.sql
@@ -136,7 +136,6 @@ BEGIN
 			u.email,
 			u.phone,
 			STRING_AGG(ur.role, ',') AS roles,
-			u.password,
 			u.profile_picture
 		FROM Users u
 		LEFT JOIN UserRoles ur ON u.user_id = ur.user_id

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -1,13 +1,8 @@
-using Api.Data.Contract;
 using Api.Data.Repository;
-using Api.Domains.Appointment.Models;
 using Api.Domains.Appointment.Repositories;
 using Api.Domains.Doctors.Repositories;
-using Api.Domains.Notification.Models;
 using Api.Domains.Notification.Repositories;
-using Api.Domains.Patients.Models;
 using Api.Domains.Patients.Repositories;
-using Api.Domains.Schedules.Models;
 using Api.Domains.Schedules.Repositories;
 using Api.Domains.Specialties.Repositories;
 using Api.Domains.Users.Repository;


### PR DESCRIPTION
**Removed the password column from the `SELECT` and `GROUP BY` clauses in the `User_CRUD` procedure to prevent SQL errors and avoid exposing sensitive data.**